### PR TITLE
Refactor login landing page

### DIFF
--- a/app/oauth.py
+++ b/app/oauth.py
@@ -79,16 +79,14 @@ def create_authorization_url():
 def callback():
 	auth_code = request.args.get("code")
 	# return token
-	return redirect(url_for('authenticate', auth_code=auth_code))
 
-@app.route("/auth/<auth_code>")
-def authenticate(auth_code):
 	post_data = {
 		"grant_type": "authorization_code", 
 		"code": auth_code, "redirect_uri": redirect_uri, 
 		"client_id": client_id, 
 		"client_secret": client_secret
 	}
+
 	headers = {
 		'Authorization': 'Basic ', 
 		'Content-type':'application/x-www-form-urlencoded', 
@@ -140,12 +138,11 @@ def authenticate(auth_code):
 
 	jwt_access_token = create_access_token(identity={"user_id":user_id})
 
-	# this all works correctly until I go to refresh.
-	# refreshing pings the Spotify OAuth2 endpoint again, which changes the acess_code
-	# The access code is then different from what I have in the db
-	# So when I try to refresh it
-	# return redirect(url_for('home', token=jwt_access_token))
-	return jsonify(jwt_access_token)
+
+	# return redirect(url_for('authenticate', auth_code=auth_code))
+	# return jsonify(jwt_access_token)
+	query_param = "?token=" + jwt_access_token
+	return redirect("http://localhost:3000/content" + query_param, code=302)
 
 
 # create a user route and test that I can get user

--- a/app/oauth.py
+++ b/app/oauth.py
@@ -144,6 +144,7 @@ def authenticate(auth_code):
 	# refreshing pings the Spotify OAuth2 endpoint again, which changes the acess_code
 	# The access code is then different from what I have in the db
 	# So when I try to refresh it
+	# return redirect(url_for('home', token=jwt_access_token))
 	return jsonify(jwt_access_token)
 
 

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -2,8 +2,29 @@ import React from 'react'
 import Button from 'react-bootstrap/Button';
 import song_image from '../example_songs.png'
 import artist_image from '../example_artists.png'
+import axios from 'axios'
 
 function LandingPage() {
+
+    const [tempAuth, setTempAuth] = ([])
+
+    let myConfig = {
+        headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*"
+        }
+     }
+
+    const tempAuthFunc = () => {
+        axios.get('http://127.0.0.1:5000/login', myConfig)
+        .then(res => {
+            window.location = res.data.data
+        })
+        .catch(err => {
+            console.log(err)
+        })
+    }
+
     return (
         <div>
             <h2>Create monthly stories based on your Spotify listening trends </h2>
@@ -16,22 +37,7 @@ function LandingPage() {
                 <img src={artist_image} className="App-photo" />
                 </li>
             </ul>
-            <Button variant="success" onClick={async () => {
-                const r = await fetch("/login", {
-                method: "GET",
-                headers: {
-                    "Content-Type": "application/json",
-                    "Access-Control-Allow-Origin": "*"
-                }
-                }).then(r => 
-                r.json().then(d => {
-                    window.location = d.data
-                    console.log(d.data);
-                }))
-            }}
-            >
-                Login
-            </Button>
+            <Button variant="success" onClick={tempAuthFunc}> Login </Button>
         </div>
     )
 }


### PR DESCRIPTION
There is a lot still going on in the OAuth flow
---
While trying to piece together the frontend jwt related stuff I ran into an issue with the previous backend setup. I now have a solution although it might be temporary. The issue is something like the following:

- The issue occurs at the end of the whole OAuth dance
- After the user has been routed from the fronted via a button to the backend, redirected to the oauth login, a new user is created and entered into the db, a jwt is created we then need to return to the frontend.
- The issue I was having is that the request from the frontend never gets a return from the frontend because it gets stopped, or there is no response, because of the whole OAuth redirect thing to sporify
- IOW, we create this  jwt but how do we send it back

There does not seem to be clear or even that much documentation on this issue. Most of the tutorials never seem to touch on this part. I did find three SO with mixed responses. They are below
- [How to provide frontend with JSON web token after server authentication?](https://stackoverflow.com/questions/41996167/how-to-provide-frontend-with-json-web-token-after-server-authentication)
- [How can i send jwt token to client after OAuth authorization?](https://stackoverflow.com/questions/63204591/how-can-i-send-jwt-token-to-client-after-oauth-autherization?rq=1)
- [How to send JWT to React client from a callback?](https://stackoverflow.com/questions/47599087/how-to-send-jwt-to-react-client-from-a-callback)
- [Blog post going over all these issues and options](http://gregtrowbridge.com/node-authentication-with-google-oauth-part2-jwts/)

### Solution
I ended up with a Flask solution that works locally. I went with the jwt as a query parameter in the URL approach for now. I am not sure about the implications down the road for hosting.

### Going forward
If sticking with the query parameter solution, I imagine there are two strategies
1. Just redirect to the page we wanted to redirect to anyway and have some React logic to check for query parameter in the string, save the jwt and remove the query parameter from url
2. Have a _fake_ loading screen whose only purpose is to extract this token. Then redirect to the `/content` page that we wanted to redirect to
